### PR TITLE
Update on Atlas Vagrant boxes

### DIFF
--- a/fodder.md
+++ b/fodder.md
@@ -1,1 +1,7 @@
 * write about MHuot's Dev-Jam Attendee document
+* Update Vagrant boxes
+** OpenNMS Horizon 17.1.1 based on [CentOS 7](https://atlas.hashicorp.com/opennms/boxes/vagrant-opennms-centos-stable)
+** OpenNMS Horizon 17.1.1 based on [Ubuntu 14.04.4 LTS](https://atlas.hashicorp.com/opennms/boxes/vagrant-opennms-ubuntu-stable)
+** OpenNMS Horizon 18 snapshot 20160325 build 368 based on [Ubuntu 14.04.4 LTS](https://atlas.hashicorp.com/opennms/boxes/vagrant-opennms-ubuntu-develop)
+** OpenNMS Horizon 17.1.1 education based on [CentOS 7](https://atlas.hashicorp.com/opennms/boxes/opennms-edu-centos-stable/)
+* Announcement [OpenNMS Drinkup](http://www.meetup.com/OpenNMS-Meetup-Group/events/229919435/)

--- a/fodder.md
+++ b/fodder.md
@@ -4,4 +4,3 @@
 ** OpenNMS Horizon 17.1.1 based on [Ubuntu 14.04.4 LTS](https://atlas.hashicorp.com/opennms/boxes/vagrant-opennms-ubuntu-stable)
 ** OpenNMS Horizon 18 snapshot 20160325 build 368 based on [Ubuntu 14.04.4 LTS](https://atlas.hashicorp.com/opennms/boxes/vagrant-opennms-ubuntu-develop)
 ** OpenNMS Horizon 17.1.1 education based on [CentOS 7](https://atlas.hashicorp.com/opennms/boxes/opennms-edu-centos-stable/)
-* Announcement [OpenNMS Drinkup](http://www.meetup.com/OpenNMS-Meetup-Group/events/229919435/)


### PR DESCRIPTION
- Update Vagrant box to Horizon 17.1.1 on Ubuntu / CentOS
- Update Vagrant box to Horizon 17.1.1 for training
- Update Vagrant box to Horizon 18 development 2016-03-25 build 368
